### PR TITLE
Only test Python 3.11 during CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,11 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
-#        python-version: ['3.11']
+        python-version: ['3.11']
 
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-
-    # - name: Install system dependencies
-    #   run: |
-    #     sudo apt-get update
-    #     sudo apt-get install -y libhdf5-dev
 
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2


### PR DESCRIPTION
Removes testing for Python 3.9 and 3.10 to save some time during CI