### PR TITLE
Fix dist exclude

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,8 +21,6 @@ classifiers = [
 [tool.hatch.build]
 exclude = [
   "/.git",
-  "/configuration",
-  "/singularity",
   "/studies",
   "/dist",
 ]


### PR DESCRIPTION
Excludes big/unnecessary folders from dist:

adds:
`/studies`

removes (legacy)
`/singularity`
`/data`