### PR TITLE
bag the xgboost estimators right at the end during uncertainty quantification

### DIFF
--- a/abil/unified_tree_or_bag.py
+++ b/abil/unified_tree_or_bag.py
@@ -275,10 +275,10 @@ def _summarize_predictions(model, y_inverse_transformer, X_predict, X_train=None
 
     if X_train is not None and y_train is not None:
         if isinstance(model, (XGBRegressor)):
-            model = BaggingRegressor(estimator=model, n_estimators=40)
+            model = BaggingRegressor(estimator=model, n_estimators=160)
             model.fit(X_train, y_train)
         elif isinstance(model, (XGBClassifier)):
-            model = BaggingClassifier(estimator=model, n_estimators=40)
+            model = BaggingClassifier(estimator=model, n_estimators=160)
             model.fit(X_train, y_train)
         train_pred_jobs = _setup_pred_jobs(
             model, 


### PR DESCRIPTION
This *just* bags the optimal/pre-specified xgboost model as a way of doing the uncertainty quantification. We shouldn't have to actually optimize these parameters, since we're just using bagging as a way to examine the model's uncertainty in predictions. 

This works pretty fast for the test case. 

I did look into swapping to `XGBRF*` estimators, but I couldn't quite figure out how to force those changes to propagate down the chain of fitting/testing/estimation. I think that this is the smallest and easiest-to-understand change that can get us where we need to go. 