### PR TITLE
update metrics to match actual model outputs

### DIFF
--- a/docs/source/user-guide/one-phase-ensemble.rst
+++ b/docs/source/user-guide/one-phase-ensemble.rst
@@ -159,9 +159,9 @@ We can also check the stats
    >>>   f"relative MAE = {obs_abundance['rMAE'][0]*100:.2f} (%)"
    >>> )
    error metrics:
-   R2 = 0.09
-   relative RMSE = 159.22 (%)
-   relative MAE = 123.73 (%)
+   R2 = 0.20
+   relative RMSE = 156.20 (%)
+   relative MAE = 121.10 (%)
 
 And plot the predictions vs observations:
 


### PR DESCRIPTION
We failed to update the documentation as part of PR https://github.com/nanophyto/Abil/pull/286 which fixed reproducibility. 

The error metrics in the 1 phase example is now matching the new model output on my local machine, which is also the number reported by althonos: https://github.com/openjournals/joss-reviews/issues/8755#issuecomment-3351575990

