### PR TITLE
python min version to 3.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ license = "MIT"
 license-files = ['LICENSE']
 description = "Aquatic Biogeochemical Interpolation Library"
 readme = "README.md"
-requires-python = ">=3.7"
+requires-python = ">=3.9"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Hi Joost, I suggest changing the python version to >= 3.9 because the old python 3.7 failed to resolve the dependency

```
uv sync
  × No solution found when resolving dependencies for split (markers: python_full_version >= '3.7' and python_full_version < '3.9'):
  ╰─▶ Because the requested Python version (>=3.7) does not satisfy Python>=3.9 and dask==2024.5.0 depends on Python>=3.9, we can
      conclude that dask==2024.5.0 cannot be used.
      And because your project depends on dask==2024.5.0, we can conclude that your project's requirements are unsatisfiable.
```