### PR TITLE
add best fit log or nolog print after regressor fitting

### DIFF
--- a/abil/log_grid_search.py
+++ b/abil/log_grid_search.py
@@ -157,7 +157,13 @@ class LogGridSearch:
                 best_transformation = "nobest"
 
         pipe = grid_search.best_estimator_
-        ttr  = pipe.named_steps["estimator"]
+        
+        # Get the TransformedTargetRegressor no matter what its container is
+        if hasattr(pipe, "named_steps"):          # Pipeline case
+            ttr = pipe.named_steps["estimator"]
+        else:                                      # Direct TTR case
+            ttr = pipe
+
         ttr.transformation_ = best_transformation
 
         return grid_search

--- a/abil/log_grid_search.py
+++ b/abil/log_grid_search.py
@@ -156,6 +156,8 @@ class LogGridSearch:
                 grid_search = grid_search1
                 best_transformation = "nobest"
 
-        grid_search.best_estimator_.transformation_ = best_transformation
+        pipe = grid_search.best_estimator_
+        ttr  = pipe.named_steps["estimator"]
+        ttr.transformation_ = best_transformation
 
         return grid_search

--- a/abil/log_grid_search.py
+++ b/abil/log_grid_search.py
@@ -123,6 +123,7 @@ class LogGridSearch:
             grid_search = GridSearchCV(model, param_grid = self.param_grid, scoring=self.scoring, refit=True,
                             cv = self.cv, verbose = self.verbose, return_train_score=True, error_score=-1e99)
             grid_search.fit(X, y)
+            best_transformation = 'log'
 
         elif log == "no":
 
@@ -130,6 +131,7 @@ class LogGridSearch:
             grid_search = GridSearchCV(model, param_grid = self.param_grid, scoring=self.scoring, refit=True,
                             cv = self.cv, verbose = self.verbose, return_train_score=True, error_score=-1e99)
             grid_search.fit(X, y)
+            best_transformation = 'nolog'
 
         elif log == "both":
 
@@ -153,6 +155,7 @@ class LogGridSearch:
             else:
                 grid_search = grid_search1
                 best_transformation = "nobest"
-            grid_search.cv_results_['best_transformation'] = best_transformation
+
+        grid_search.best_estimator_.transformation_ = best_transformation
 
         return grid_search

--- a/abil/post.py
+++ b/abil/post.py
@@ -413,86 +413,110 @@ class AbilPostProcessor:
                 raise ValueError("classifiers are not supported")
 
             elif self.model_type == "zir":
+                # Extract inner estimators
+                reg_est = get_inner_estimator(m.regressor_.regressor)
+                transformation = get_transformation(m.regressor_.regressor)
+
+                clf_est = get_inner_estimator(m.classifier)
+
                 if model == "rf":
-                    max_depth_reg = m.regressor_.regressor.named_steps.estimator.max_depth
-                    max_features_reg = m.regressor_.regressor.named_steps.estimator.max_features
-                    max_samples_reg = m.regressor_.regressor.named_steps.estimator.max_samples
-                    min_samples_leaf_reg = m.regressor_.regressor.named_steps.estimator.min_samples_leaf
-                    n_estimators_reg = m.regressor_.regressor.named_steps.estimator.n_estimators
-                    transformation = m.regressor_.regressor.named_steps.estimator.transformation_
+                    max_depth_reg = reg_est.max_depth
+                    max_features_reg = reg_est.max_features
+                    max_samples_reg = reg_est.max_samples
+                    min_samples_leaf_reg = reg_est.min_samples_leaf
+                    n_estimators_reg = reg_est.n_estimators
 
-                    n_estimators_clf = m.classifier.named_steps.estimator.n_estimators
-                    max_features_clf = m.classifier.named_steps.estimator.max_features
-                    max_depth_clf = m.classifier.named_steps.estimator.max_depth
-                    min_samples_leaf_clf = m.classifier.named_steps.estimator.min_samples_leaf
-                    max_samples_clf = m.classifier.named_steps.estimator.max_samples
+                    n_estimators_clf = clf_est.n_estimators
+                    max_features_clf = clf_est.max_features
+                    max_depth_clf = clf_est.max_depth
+                    min_samples_leaf_clf = clf_est.min_samples_leaf
+                    max_samples_clf = clf_est.max_samples
 
-                    parameters = pd.DataFrame({'target':[target], 'reg_n_estimators':[n_estimators_reg], 
-                                            'reg_max_features':[max_features_reg], 'reg_max_depth':[max_depth_reg], 
-                                            'reg_min_samples_leaf':[min_samples_leaf_reg], 'reg_max_samples':[max_samples_reg],
-                                            'reg_transformation':[transformation],
-                                            'clf_n_estimators':[n_estimators_clf], 
-                                            'clf_max_features':[max_features_clf], 'clf_max_depth':[max_depth_clf], 
-                                            'clf_min_samples_leaf':[min_samples_leaf_clf], 'clf_max_samples':[max_samples_clf]
-                                            })
+                    parameters = pd.DataFrame({
+                        'target':[target],
+                        'reg_n_estimators':[n_estimators_reg],
+                        'reg_max_features':[max_features_reg],
+                        'reg_max_depth':[max_depth_reg],
+                        'reg_min_samples_leaf':[min_samples_leaf_reg],
+                        'reg_max_samples':[max_samples_reg],
+                        'reg_transformation':[transformation],
+                        'clf_n_estimators':[n_estimators_clf],
+                        'clf_max_features':[max_features_clf],
+                        'clf_max_depth':[max_depth_clf],
+                        'clf_min_samples_leaf':[min_samples_leaf_clf],
+                        'clf_max_samples':[max_samples_clf]
+                    })
                     all_parameters.append(parameters)
 
                 elif model == "xgb":
-                    learning_rate_reg = m.regressor_.regressor.named_steps.estimator.learning_rate
-                    n_estimators_reg = m.regressor_.regressor.named_steps.estimator.n_estimators
-                    max_depth_reg = m.regressor_.regressor.named_steps.estimator.max_depth
-                    subsample_reg = m.regressor_.regressor.named_steps.estimator.subsample
-                    colsample_bytree_reg = m.regressor_.regressor.named_steps.estimator.colsample_bytree
-                    gamma_reg = m.regressor_.regressor.named_steps.estimator.gamma
-                    alpha_reg = m.regressor_.regressor.named_steps.estimator.reg_alpha
-                    transformation = m.regressor_.regressor.named_steps.estimator.transformation_
+                    learning_rate_reg = reg_est.learning_rate
+                    n_estimators_reg = reg_est.n_estimators
+                    max_depth_reg = reg_est.max_depth
+                    subsample_reg = reg_est.subsample
+                    colsample_bytree_reg = reg_est.colsample_bytree
+                    gamma_reg = reg_est.gamma
+                    alpha_reg = reg_est.reg_alpha
 
-                    learning_rate_clf = m.classifier.named_steps.estimator.learning_rate
-                    n_estimators_clf = m.classifier.named_steps.estimator.n_estimators
-                    max_depth_clf = m.classifier.named_steps.estimator.max_depth
-                    subsample_clf = m.classifier.named_steps.estimator.subsample
-                    colsample_bytree_clf = m.classifier.named_steps.estimator.colsample_bytree
-                    gamma_clf = m.classifier.named_steps.estimator.gamma
-                    alpha_clf = m.classifier.named_steps.estimator.reg_alpha
+                    learning_rate_clf = clf_est.learning_rate
+                    n_estimators_clf = clf_est.n_estimators
+                    max_depth_clf = clf_est.max_depth
+                    subsample_clf = clf_est.subsample
+                    colsample_bytree_clf = clf_est.colsample_bytree
+                    gamma_clf = clf_est.gamma
+                    alpha_clf = clf_est.reg_alpha
 
-
-                    parameters = pd.DataFrame({'target':[target], 'reg_learning_rate':[learning_rate_reg], 'reg_n_estimators':[n_estimators_reg], 
-                                            'reg_max_depth':[max_depth_reg], 'reg_subsample':[subsample_reg], 'reg_colsample_bytree':[colsample_bytree_reg],
-                                            'reg_learning_rate':[learning_rate_reg], 'reg_gamma':[gamma_reg], 'reg_alpha':[alpha_reg],
-                                            'reg_transformation':[transformation],
-                                            'clf_learning_rate':[learning_rate_clf], 'clf_n_estimators':[n_estimators_clf], 
-                                            'clf_max_depth':[max_depth_clf], 'clf_subsample':[subsample_clf], 'clf_colsample_bytree':[colsample_bytree_clf],
-                                            'clf_learning_rate':[learning_rate_clf], 'clf_gamma':[gamma_clf], 'clf_alpha':[alpha_clf]                                           
-                                            })
+                    parameters = pd.DataFrame({
+                        'target':[target],
+                        'reg_learning_rate':[learning_rate_reg],
+                        'reg_n_estimators':[n_estimators_reg],
+                        'reg_max_depth':[max_depth_reg],
+                        'reg_subsample':[subsample_reg],
+                        'reg_colsample_bytree':[colsample_bytree_reg],
+                        'reg_gamma':[gamma_reg],
+                        'reg_alpha':[alpha_reg],
+                        'reg_transformation':[transformation],
+                        'clf_learning_rate':[learning_rate_clf],
+                        'clf_n_estimators':[n_estimators_clf],
+                        'clf_max_depth':[max_depth_clf],
+                        'clf_subsample':[subsample_clf],
+                        'clf_colsample_bytree':[colsample_bytree_clf],
+                        'clf_gamma':[gamma_clf],
+                        'clf_alpha':[alpha_clf]
+                    })
                     all_parameters.append(parameters)
 
                 elif model == "knn":
-                    max_samples_reg = m.regressor_.regressor.named_steps.estimator.max_samples
-                    max_features_reg = m.regressor_.regressor.named_steps.estimator.max_features
-                    leaf_size_reg = m.regressor_.regressor.named_steps.estimator.estimator.leaf_size
-                    n_neighbors_reg = m.regressor_.regressor.named_steps.estimator.estimator.n_neighbors
-                    p_reg = m.regressor_.regressor.named_steps.estimator.estimator.p
-                    weights_reg = m.regressor_.regressor.named_steps.estimator.estimator.weights
-                    transformation = m.regressor_.regressor.named_steps.estimator.transformation_
+                    max_samples_reg = reg_est.max_samples
+                    max_features_reg = reg_est.max_features
+                    leaf_size_reg = reg_est.estimator.leaf_size
+                    n_neighbors_reg = reg_est.estimator.n_neighbors
+                    p_reg = reg_est.estimator.p
+                    weights_reg = reg_est.estimator.weights
 
-                    max_samples_clf = m.classifier.named_steps.estimator.max_samples
-                    max_features_clf = m.classifier.named_steps.estimator.max_features
-                    leaf_size_clf = m.classifier.named_steps.estimator.estimator.leaf_size
-                    n_neighbors_clf = m.classifier.named_steps.estimator.estimator.n_neighbors
-                    p_clf = m.classifier.named_steps.estimator.estimator.p
-                    weights_clf = m.classifier.named_steps.estimator.estimator.weights
+                    max_samples_clf = clf_est.max_samples
+                    max_features_clf = clf_est.max_features
+                    leaf_size_clf = clf_est.estimator.leaf_size
+                    n_neighbors_clf = clf_est.estimator.n_neighbors
+                    p_clf = clf_est.estimator.p
+                    weights_clf = clf_est.estimator.weights
 
-
-
-                    parameters = pd.DataFrame({'target':[target], 'reg_max_samples':[max_samples_reg], 'reg_max_features':[max_features_reg],
-                                            'reg_leaf_size':[leaf_size_reg], 'reg_n_neighbors':[n_neighbors_reg], 
-                                            'reg_p':[p_reg], 'reg_weights':[weights_reg],
-                                            'reg_transformation':[transformation],
-                                            'clf_max_samples':[max_samples_clf], 'clf_max_features':[max_features_clf],
-                                            'clf_leaf_size':[leaf_size_clf], 'clf_n_neighbors':[n_neighbors_clf], 
-                                            'clf_p':[p_clf], 'clf_weights':[weights_clf]
-                                            })
-                    all_parameters.append(parameters) 
+                    parameters = pd.DataFrame({
+                        'target':[target],
+                        'reg_max_samples':[max_samples_reg],
+                        'reg_max_features':[max_features_reg],
+                        'reg_leaf_size':[leaf_size_reg],
+                        'reg_n_neighbors':[n_neighbors_reg],
+                        'reg_p':[p_reg],
+                        'reg_weights':[weights_reg],
+                        'reg_transformation':[transformation],
+                        'clf_max_samples':[max_samples_clf],
+                        'clf_max_features':[max_features_clf],
+                        'clf_leaf_size':[leaf_size_clf],
+                        'clf_n_neighbors':[n_neighbors_clf],
+                        'clf_p':[p_clf],
+                        'clf_weights':[weights_clf]
+                    })
+                    all_parameters.append(parameters)
 
         all_parameters= pd.concat(all_parameters)
         #make new dir if needed

--- a/abil/post.py
+++ b/abil/post.py
@@ -313,7 +313,21 @@ class AbilPostProcessor:
         The parameters for each target are aggregated into a DataFrame and saved as a CSV file in the 
         "posts/parameters" directory.
         """
-        
+        def get_inner_estimator(reg):
+            """
+            Returns the actual estimator inside a pipeline or the bare estimator.
+            """
+            if hasattr(reg, "named_steps"):          # Pipeline case
+                return reg.named_steps["estimator"]
+            return reg                                 # Bare estimator case
+
+        def get_transformation(reg):
+            """
+            Returns the transformation_ attribute if it exists, else None.
+            """
+            est = get_inner_estimator(reg)
+            return getattr(est, "transformation_", None)
+
         all_parameters = []
 
         for i in range(len(self.unique_targets)):
@@ -329,42 +343,71 @@ class AbilPostProcessor:
             if self.model_type == "reg":
 
                 if model == "rf":
-                    max_depth = m.regressor_.named_steps.estimator.max_depth
-                    max_features = m.regressor_.named_steps.estimator.max_features
-                    max_samples = m.regressor_.named_steps.estimator.max_samples
-                    min_samples_leaf = m.regressor_.named_steps.estimator.min_samples_leaf
-                    n_estimators = m.regressor_.named_steps.estimator.n_estimators
-                    transformation = m.regressor_.transformation_
-                    parameters = pd.DataFrame({'target':[target], 'n_estimators':[n_estimators], 'max_features':[max_features], 'max_depth':[max_depth], 
-                                            'min_samples_leaf':[min_samples_leaf], 'max_samples':[max_samples], 'transformation':[transformation]
-                                            })
+                    est = get_inner_estimator(m.regressor_)
+                    transformation = get_transformation(m.regressor_)
+
+                    max_depth = est.max_depth
+                    max_features = est.max_features
+                    max_samples = est.max_samples
+                    min_samples_leaf = est.min_samples_leaf
+                    n_estimators = est.n_estimators
+
+                    parameters = pd.DataFrame({
+                        'target': [target],
+                        'n_estimators': [n_estimators],
+                        'max_features': [max_features],
+                        'max_depth': [max_depth],
+                        'min_samples_leaf': [min_samples_leaf],
+                        'max_samples': [max_samples],
+                        'transformation': [transformation]
+                    })
                     all_parameters.append(parameters)
                 elif model == "xgb":
-                    learning_rate = m.regressor_.named_steps.estimator.learning_rate
-                    n_estimators = m.regressor_.named_steps.estimator.n_estimators
-                    max_depth = m.regressor_.named_steps.estimator.max_depth
-                    subsample = m.regressor_.named_steps.estimator.subsample
-                    colsample_bytree = m.regressor_.named_steps.estimator.colsample_bytree
-                    gamma = m.regressor_.named_steps.estimator.gamma
-                    alpha = m.regressor_.named_steps.estimator.reg_alpha
-                    transformation = m.regressor_.transformation_
-                    parameters = pd.DataFrame({'target':[target], 'learning_rate':[learning_rate], 'n_estimators':[n_estimators], 
-                                            'max_depth':[max_depth], 'subsample':[subsample], 'colsample_bytree':[colsample_bytree],
-                                            'learning_rate':[learning_rate], 'gamma':[gamma], 'alpha':[alpha], 'transformation':[transformation]                                           
-                                            })
+                    est = get_inner_estimator(m.regressor_)
+                    transformation = get_transformation(m.regressor_)
+
+                    learning_rate = est.learning_rate
+                    n_estimators = est.n_estimators
+                    max_depth = est.max_depth
+                    subsample = est.subsample
+                    colsample_bytree = est.colsample_bytree
+                    gamma = est.gamma
+                    alpha = est.reg_alpha
+
+                    parameters = pd.DataFrame({
+                        'target': [target],
+                        'learning_rate': [learning_rate],
+                        'n_estimators': [n_estimators],
+                        'max_depth': [max_depth],
+                        'subsample': [subsample],
+                        'colsample_bytree': [colsample_bytree],
+                        'gamma': [gamma],
+                        'alpha': [alpha],
+                        'transformation': [transformation]
+                    })
                     all_parameters.append(parameters)
                 elif model == "knn":
-                    max_samples = m.regressor_.named_steps.estimator.max_samples
-                    max_features = m.regressor_.named_steps.estimator.max_features
-                    leaf_size = m.regressor_.named_steps.estimator.estimator.leaf_size
-                    n_neighbors = m.regressor_.named_steps.estimator.estimator.n_neighbors
-                    p = m.regressor_.named_steps.estimator.estimator.p
-                    weights = m.regressor_.named_steps.estimator.estimator.weights
-                    transformation = m.regressor_.transformation_
-                    parameters = pd.DataFrame({'target':[target], 'max_samples':[max_samples], 'max_features':[max_features],
-                                            'leaf_size':[leaf_size], 'n_neighbors':[n_neighbors], 'p':[p], 'weights':[weights],'transformation':[transformation]
-                                            })
-                    all_parameters.append(parameters) 
+                    est = get_inner_estimator(m.regressor_)
+                    transformation = get_transformation(m.regressor_)
+
+                    max_samples = est.max_samples
+                    max_features = est.max_features
+                    leaf_size = est.estimator.leaf_size  # if wrapped in some extra estimator
+                    n_neighbors = est.estimator.n_neighbors
+                    p = est.estimator.p
+                    weights = est.estimator.weights
+
+                    parameters = pd.DataFrame({
+                        'target': [target],
+                        'max_samples': [max_samples],
+                        'max_features': [max_features],
+                        'leaf_size': [leaf_size],
+                        'n_neighbors': [n_neighbors],
+                        'p': [p],
+                        'weights': [weights],
+                        'transformation': [transformation]
+                    })
+                    all_parameters.append(parameters)
 
             elif self.model_type == "clf":
                 raise ValueError("classifiers are not supported")

--- a/abil/post.py
+++ b/abil/post.py
@@ -334,7 +334,7 @@ class AbilPostProcessor:
                     max_samples = m.regressor_.named_steps.estimator.max_samples
                     min_samples_leaf = m.regressor_.named_steps.estimator.min_samples_leaf
                     n_estimators = m.regressor_.named_steps.estimator.n_estimators
-                    transformation = m.transformation_
+                    transformation = m.regressor_.named_steps.estimator.transformation_
                     parameters = pd.DataFrame({'target':[target], 'n_estimators':[n_estimators], 'max_features':[max_features], 'max_depth':[max_depth], 
                                             'min_samples_leaf':[min_samples_leaf], 'max_samples':[max_samples], 'transformation':[transformation]
                                             })
@@ -347,7 +347,7 @@ class AbilPostProcessor:
                     colsample_bytree = m.regressor_.named_steps.estimator.colsample_bytree
                     gamma = m.regressor_.named_steps.estimator.gamma
                     alpha = m.regressor_.named_steps.estimator.reg_alpha
-                    transformation = m.regressor_.transformation_
+                    transformation = m.regressor_.named_steps.estimator.regressor_.transformation_
                     parameters = pd.DataFrame({'target':[target], 'learning_rate':[learning_rate], 'n_estimators':[n_estimators], 
                                             'max_depth':[max_depth], 'subsample':[subsample], 'colsample_bytree':[colsample_bytree],
                                             'learning_rate':[learning_rate], 'gamma':[gamma], 'alpha':[alpha], 'transformation':[transformation]                                           
@@ -360,7 +360,7 @@ class AbilPostProcessor:
                     n_neighbors = m.regressor_.named_steps.estimator.estimator.n_neighbors
                     p = m.regressor_.named_steps.estimator.estimator.p
                     weights = m.regressor_.named_steps.estimator.estimator.weights
-                    transformation = m.transformation_
+                    transformation = m.regressor_.named_steps.estimator.transformation_
                     parameters = pd.DataFrame({'target':[target], 'max_samples':[max_samples], 'max_features':[max_features],
                                             'leaf_size':[leaf_size], 'n_neighbors':[n_neighbors], 'p':[p], 'weights':[weights],'transformation':[transformation]
                                             })
@@ -376,7 +376,7 @@ class AbilPostProcessor:
                     max_samples_reg = m.regressor_.regressor.named_steps.estimator.max_samples
                     min_samples_leaf_reg = m.regressor_.regressor.named_steps.estimator.min_samples_leaf
                     n_estimators_reg = m.regressor_.regressor.named_steps.estimator.n_estimators
-                    transformation = m.regressor_.transformation_
+                    transformation = m.regressor_.regressor.named_steps.estimator.transformation_
 
                     n_estimators_clf = m.classifier.named_steps.estimator.n_estimators
                     max_features_clf = m.classifier.named_steps.estimator.max_features
@@ -402,7 +402,7 @@ class AbilPostProcessor:
                     colsample_bytree_reg = m.regressor_.regressor.named_steps.estimator.colsample_bytree
                     gamma_reg = m.regressor_.regressor.named_steps.estimator.gamma
                     alpha_reg = m.regressor_.regressor.named_steps.estimator.reg_alpha
-                    transformation = m.regressor_.transformation_
+                    transformation = m.regressor_.regressor.named_steps.estimator.transformation_
 
                     learning_rate_clf = m.classifier.named_steps.estimator.learning_rate
                     n_estimators_clf = m.classifier.named_steps.estimator.n_estimators
@@ -430,7 +430,7 @@ class AbilPostProcessor:
                     n_neighbors_reg = m.regressor_.regressor.named_steps.estimator.estimator.n_neighbors
                     p_reg = m.regressor_.regressor.named_steps.estimator.estimator.p
                     weights_reg = m.regressor_.regressor.named_steps.estimator.estimator.weights
-                    transformation = m.regressor_.transformation_
+                    transformation = m.regressor_.regressor.named_steps.estimator.transformation_
 
                     max_samples_clf = m.classifier.named_steps.estimator.max_samples
                     max_features_clf = m.classifier.named_steps.estimator.max_features

--- a/abil/post.py
+++ b/abil/post.py
@@ -334,8 +334,9 @@ class AbilPostProcessor:
                     max_samples = m.regressor_.named_steps.estimator.max_samples
                     min_samples_leaf = m.regressor_.named_steps.estimator.min_samples_leaf
                     n_estimators = m.regressor_.named_steps.estimator.n_estimators
+                    transformation = m.transformation_
                     parameters = pd.DataFrame({'target':[target], 'n_estimators':[n_estimators], 'max_features':[max_features], 'max_depth':[max_depth], 
-                                            'min_samples_leaf':[min_samples_leaf], 'max_samples':[max_samples]
+                                            'min_samples_leaf':[min_samples_leaf], 'max_samples':[max_samples], 'transformation':[transformation]
                                             })
                     all_parameters.append(parameters)
                 elif model == "xgb":
@@ -346,9 +347,10 @@ class AbilPostProcessor:
                     colsample_bytree = m.regressor_.named_steps.estimator.colsample_bytree
                     gamma = m.regressor_.named_steps.estimator.gamma
                     alpha = m.regressor_.named_steps.estimator.reg_alpha
+                    transformation = m.transformation_
                     parameters = pd.DataFrame({'target':[target], 'learning_rate':[learning_rate], 'n_estimators':[n_estimators], 
                                             'max_depth':[max_depth], 'subsample':[subsample], 'colsample_bytree':[colsample_bytree],
-                                            'learning_rate':[learning_rate], 'gamma':[gamma], 'alpha':[alpha]                                           
+                                            'learning_rate':[learning_rate], 'gamma':[gamma], 'alpha':[alpha], 'transformation':[transformation]                                           
                                             })
                     all_parameters.append(parameters)
                 elif model == "knn":
@@ -358,8 +360,9 @@ class AbilPostProcessor:
                     n_neighbors = m.regressor_.named_steps.estimator.estimator.n_neighbors
                     p = m.regressor_.named_steps.estimator.estimator.p
                     weights = m.regressor_.named_steps.estimator.estimator.weights
+                    transformation = m.transformation_
                     parameters = pd.DataFrame({'target':[target], 'max_samples':[max_samples], 'max_features':[max_features],
-                                            'leaf_size':[leaf_size], 'n_neighbors':[n_neighbors], 'p':[p], 'weights':[weights]
+                                            'leaf_size':[leaf_size], 'n_neighbors':[n_neighbors], 'p':[p], 'weights':[weights],'transformation':[transformation]
                                             })
                     all_parameters.append(parameters) 
 
@@ -373,6 +376,7 @@ class AbilPostProcessor:
                     max_samples_reg = m.regressor_.regressor.named_steps.estimator.max_samples
                     min_samples_leaf_reg = m.regressor_.regressor.named_steps.estimator.min_samples_leaf
                     n_estimators_reg = m.regressor_.regressor.named_steps.estimator.n_estimators
+                    transformation = m.transformation_
 
                     n_estimators_clf = m.classifier.named_steps.estimator.n_estimators
                     max_features_clf = m.classifier.named_steps.estimator.max_features
@@ -383,6 +387,7 @@ class AbilPostProcessor:
                     parameters = pd.DataFrame({'target':[target], 'reg_n_estimators':[n_estimators_reg], 
                                             'reg_max_features':[max_features_reg], 'reg_max_depth':[max_depth_reg], 
                                             'reg_min_samples_leaf':[min_samples_leaf_reg], 'reg_max_samples':[max_samples_reg],
+                                            'reg_transformation':[transformation],
                                             'clf_n_estimators':[n_estimators_clf], 
                                             'clf_max_features':[max_features_clf], 'clf_max_depth':[max_depth_clf], 
                                             'clf_min_samples_leaf':[min_samples_leaf_clf], 'clf_max_samples':[max_samples_clf]
@@ -397,6 +402,7 @@ class AbilPostProcessor:
                     colsample_bytree_reg = m.regressor_.regressor.named_steps.estimator.colsample_bytree
                     gamma_reg = m.regressor_.regressor.named_steps.estimator.gamma
                     alpha_reg = m.regressor_.regressor.named_steps.estimator.reg_alpha
+                    transformation = m.transformation_
 
                     learning_rate_clf = m.classifier.named_steps.estimator.learning_rate
                     n_estimators_clf = m.classifier.named_steps.estimator.n_estimators
@@ -410,6 +416,7 @@ class AbilPostProcessor:
                     parameters = pd.DataFrame({'target':[target], 'reg_learning_rate':[learning_rate_reg], 'reg_n_estimators':[n_estimators_reg], 
                                             'reg_max_depth':[max_depth_reg], 'reg_subsample':[subsample_reg], 'reg_colsample_bytree':[colsample_bytree_reg],
                                             'reg_learning_rate':[learning_rate_reg], 'reg_gamma':[gamma_reg], 'reg_alpha':[alpha_reg],
+                                            'reg_transformation':[transformation],
                                             'clf_learning_rate':[learning_rate_clf], 'clf_n_estimators':[n_estimators_clf], 
                                             'clf_max_depth':[max_depth_clf], 'clf_subsample':[subsample_clf], 'clf_colsample_bytree':[colsample_bytree_clf],
                                             'clf_learning_rate':[learning_rate_clf], 'clf_gamma':[gamma_clf], 'clf_alpha':[alpha_clf]                                           
@@ -423,6 +430,7 @@ class AbilPostProcessor:
                     n_neighbors_reg = m.regressor_.regressor.named_steps.estimator.estimator.n_neighbors
                     p_reg = m.regressor_.regressor.named_steps.estimator.estimator.p
                     weights_reg = m.regressor_.regressor.named_steps.estimator.estimator.weights
+                    transformation = m.transformation_
 
                     max_samples_clf = m.classifier.named_steps.estimator.max_samples
                     max_features_clf = m.classifier.named_steps.estimator.max_features
@@ -436,6 +444,7 @@ class AbilPostProcessor:
                     parameters = pd.DataFrame({'target':[target], 'reg_max_samples':[max_samples_reg], 'reg_max_features':[max_features_reg],
                                             'reg_leaf_size':[leaf_size_reg], 'reg_n_neighbors':[n_neighbors_reg], 
                                             'reg_p':[p_reg], 'reg_weights':[weights_reg],
+                                            'reg_transformation':[transformation],
                                             'clf_max_samples':[max_samples_clf], 'clf_max_features':[max_features_clf],
                                             'clf_leaf_size':[leaf_size_clf], 'clf_n_neighbors':[n_neighbors_clf], 
                                             'clf_p':[p_clf], 'clf_weights':[weights_clf]

--- a/abil/post.py
+++ b/abil/post.py
@@ -347,7 +347,7 @@ class AbilPostProcessor:
                     colsample_bytree = m.regressor_.named_steps.estimator.colsample_bytree
                     gamma = m.regressor_.named_steps.estimator.gamma
                     alpha = m.regressor_.named_steps.estimator.reg_alpha
-                    transformation = m.transformation_
+                    transformation = m.regressor_.transformation_
                     parameters = pd.DataFrame({'target':[target], 'learning_rate':[learning_rate], 'n_estimators':[n_estimators], 
                                             'max_depth':[max_depth], 'subsample':[subsample], 'colsample_bytree':[colsample_bytree],
                                             'learning_rate':[learning_rate], 'gamma':[gamma], 'alpha':[alpha], 'transformation':[transformation]                                           
@@ -376,7 +376,7 @@ class AbilPostProcessor:
                     max_samples_reg = m.regressor_.regressor.named_steps.estimator.max_samples
                     min_samples_leaf_reg = m.regressor_.regressor.named_steps.estimator.min_samples_leaf
                     n_estimators_reg = m.regressor_.regressor.named_steps.estimator.n_estimators
-                    transformation = m.transformation_
+                    transformation = m.regressor_.transformation_
 
                     n_estimators_clf = m.classifier.named_steps.estimator.n_estimators
                     max_features_clf = m.classifier.named_steps.estimator.max_features
@@ -402,7 +402,7 @@ class AbilPostProcessor:
                     colsample_bytree_reg = m.regressor_.regressor.named_steps.estimator.colsample_bytree
                     gamma_reg = m.regressor_.regressor.named_steps.estimator.gamma
                     alpha_reg = m.regressor_.regressor.named_steps.estimator.reg_alpha
-                    transformation = m.transformation_
+                    transformation = m.regressor_.transformation_
 
                     learning_rate_clf = m.classifier.named_steps.estimator.learning_rate
                     n_estimators_clf = m.classifier.named_steps.estimator.n_estimators
@@ -430,7 +430,7 @@ class AbilPostProcessor:
                     n_neighbors_reg = m.regressor_.regressor.named_steps.estimator.estimator.n_neighbors
                     p_reg = m.regressor_.regressor.named_steps.estimator.estimator.p
                     weights_reg = m.regressor_.regressor.named_steps.estimator.estimator.weights
-                    transformation = m.transformation_
+                    transformation = m.regressor_.transformation_
 
                     max_samples_clf = m.classifier.named_steps.estimator.max_samples
                     max_features_clf = m.classifier.named_steps.estimator.max_features

--- a/abil/post.py
+++ b/abil/post.py
@@ -334,7 +334,7 @@ class AbilPostProcessor:
                     max_samples = m.regressor_.named_steps.estimator.max_samples
                     min_samples_leaf = m.regressor_.named_steps.estimator.min_samples_leaf
                     n_estimators = m.regressor_.named_steps.estimator.n_estimators
-                    transformation = m.regressor_.named_steps.estimator.transformation_
+                    transformation = m.regressor_.transformation_
                     parameters = pd.DataFrame({'target':[target], 'n_estimators':[n_estimators], 'max_features':[max_features], 'max_depth':[max_depth], 
                                             'min_samples_leaf':[min_samples_leaf], 'max_samples':[max_samples], 'transformation':[transformation]
                                             })
@@ -347,7 +347,7 @@ class AbilPostProcessor:
                     colsample_bytree = m.regressor_.named_steps.estimator.colsample_bytree
                     gamma = m.regressor_.named_steps.estimator.gamma
                     alpha = m.regressor_.named_steps.estimator.reg_alpha
-                    transformation = m.regressor_.named_steps.estimator.regressor_.transformation_
+                    transformation = m.regressor_.transformation_
                     parameters = pd.DataFrame({'target':[target], 'learning_rate':[learning_rate], 'n_estimators':[n_estimators], 
                                             'max_depth':[max_depth], 'subsample':[subsample], 'colsample_bytree':[colsample_bytree],
                                             'learning_rate':[learning_rate], 'gamma':[gamma], 'alpha':[alpha], 'transformation':[transformation]                                           
@@ -360,7 +360,7 @@ class AbilPostProcessor:
                     n_neighbors = m.regressor_.named_steps.estimator.estimator.n_neighbors
                     p = m.regressor_.named_steps.estimator.estimator.p
                     weights = m.regressor_.named_steps.estimator.estimator.weights
-                    transformation = m.regressor_.named_steps.estimator.transformation_
+                    transformation = m.regressor_.transformation_
                     parameters = pd.DataFrame({'target':[target], 'max_samples':[max_samples], 'max_features':[max_features],
                                             'leaf_size':[leaf_size], 'n_neighbors':[n_neighbors], 'p':[p], 'weights':[weights],'transformation':[transformation]
                                             })

--- a/abil/tune.py
+++ b/abil/tune.py
@@ -256,7 +256,7 @@ class ModelTuner:
                 reg_grid_search = reg.transformed_fit(X_train, y, log, self.model_config['predictors'].copy())
             
             if log == 'both':
-                logger.info(f"best fit: {reg_grid_search.best_estimator_.transformation_}")
+                logger.info(f"best fit: {reg_grid_search.best_estimator_.named_steps["estimator"].transformation_}")
             m2 = reg_grid_search.best_estimator_
 
 

--- a/abil/tune.py
+++ b/abil/tune.py
@@ -256,7 +256,7 @@ class ModelTuner:
                 reg_grid_search = reg.transformed_fit(X_train, y, log, self.model_config['predictors'].copy())
             
             if log == 'both':
-                logger.info(f"best fit: {reg_grid_search.best_estimator_.named_steps["estimator"].transformation_}")
+                logger.info(f"best fit: {reg_grid_search.best_estimator_.named_steps['estimator'].transformation_}")
             m2 = reg_grid_search.best_estimator_
 
 

--- a/abil/tune.py
+++ b/abil/tune.py
@@ -254,7 +254,9 @@ class ModelTuner:
                 reg = LogGridSearch(reg_pipe, verbose = self.verbose, cv=cv, 
                                     param_grid=reg_param_grid, scoring='r2', regions=self.regions)
                 reg_grid_search = reg.transformed_fit(X_train, y, log, self.model_config['predictors'].copy())
-
+            
+            if log == 'both':
+                logger.info(f"best fit: {reg_grid_search.cv_results_['best_transformation']}")
             m2 = reg_grid_search.best_estimator_
 
 

--- a/abil/tune.py
+++ b/abil/tune.py
@@ -256,7 +256,14 @@ class ModelTuner:
                 reg_grid_search = reg.transformed_fit(X_train, y, log, self.model_config['predictors'].copy())
             
             if log == 'both':
-                logger.info(f"best fit: {reg_grid_search.best_estimator_.named_steps['estimator'].transformation_}")
+                best = reg_grid_search.best_estimator_
+                # If it's a pipeline → extract "estimator"
+                if hasattr(best, "named_steps"):
+                    ttr = best.named_steps["estimator"]
+                else:
+                    # Bare Transformed Target Regressor
+                    ttr = best
+                logger.info(f"best fit: {ttr.transformation_}")
             m2 = reg_grid_search.best_estimator_
 
 

--- a/abil/tune.py
+++ b/abil/tune.py
@@ -256,7 +256,7 @@ class ModelTuner:
                 reg_grid_search = reg.transformed_fit(X_train, y, log, self.model_config['predictors'].copy())
             
             if log == 'both':
-                logger.info(f"best fit: {reg_grid_search.cv_results_['best_transformation']}")
+                logger.info(f"best fit: {reg_grid_search.best_estimator_.transformation_}")
             m2 = reg_grid_search.best_estimator_
 
 

--- a/abil/zir.py
+++ b/abil/zir.py
@@ -67,6 +67,20 @@ class ZeroInflatedRegressor(BaseEstimator, RegressorMixin):
 
         # Ensure regressor_ is assigned
         self.regressor_ = clone(self.regressor)
+
+        try:
+            # original pipeline from LogGridSearch
+            orig_ttr = self.regressor.named_steps["estimator"]
+
+            # cloned pipeline we actually fit
+            new_ttr  = self.regressor_.named_steps["estimator"]
+
+            # copy transformation flag (e.g. 'log', 'nolog', 'nobest')
+            new_ttr.transformation_ = getattr(orig_ttr, "transformation_", None)
+
+        except Exception:
+            # If it's not a pipeline or missing the estimator step, just skip it.
+            pass
         
         y_pred_proba = self.classifier_.predict_proba(X)[:, 1]
         y_pred = (y_pred_proba >= self.threshold).astype(int)

--- a/abil/zir.py
+++ b/abil/zir.py
@@ -69,17 +69,16 @@ class ZeroInflatedRegressor(BaseEstimator, RegressorMixin):
         self.regressor_ = clone(self.regressor)
 
         try:
-            # original pipeline from LogGridSearch
-            orig_ttr = self.regressor.named_steps["estimator"]
-
-            # cloned pipeline we actually fit
-            new_ttr  = self.regressor_.named_steps["estimator"]
-
-            # copy transformation flag (e.g. 'log', 'nolog', 'nobest')
+            if hasattr(self.regressor, "named_steps"):
+                orig_ttr = self.regressor.named_steps["estimator"]
+                new_ttr  = self.regressor_.named_steps["estimator"]
+            else:
+                orig_ttr = self.regressor
+                new_ttr  = self.regressor_
+            
             new_ttr.transformation_ = getattr(orig_ttr, "transformation_", None)
 
         except Exception:
-            # If it's not a pipeline or missing the estimator step, just skip it.
             pass
         
         y_pred_proba = self.classifier_.predict_proba(X)[:, 1]

--- a/tests/test.py
+++ b/tests/test.py
@@ -31,8 +31,8 @@ class TestRegressors(unittest.TestCase):
     def test_post_ensemble(self):
         m = tune(self.X_train, self.y, self.model_config)
         m.train(model="rf", log="yes")
-        m.train(model="xgb", log="yes")
-        m.train(model="knn", log="yes")
+        m.train(model="xgb", log="both")
+        m.train(model="knn", log="no")
 
         m = predict(self.X_train, self.y, self.X_predict, self.model_config, n_jobs=self.model_config['n_threads'])
         m.make_prediction()
@@ -125,8 +125,8 @@ class Test2Phase(unittest.TestCase):
         m = tune(self.X_train, self.y, self.model_config)
 
         m.train(model="rf", log="yes")
-        m.train(model="xgb", log="yes")
-        m.train(model="knn", log="yes")
+        m.train(model="xgb", log="both")
+        m.train(model="knn", log="no")
 
         m = predict(self.X_train, self.y, self.X_predict, self.model_config, n_jobs=self.model_config['n_threads'])
         m.make_prediction()

--- a/tests/test.py
+++ b/tests/test.py
@@ -99,9 +99,9 @@ class TestRegressors(unittest.TestCase):
             os.path.join("tests", "ModelOutput", "regressor", "posts", "integrated_totals", "ens_integrated_totals_ci95_LL_poc.csv")
         )["total"].iat[0]
 
-        self.assertAlmostEqual(integrated_total_poc_mean, 1.013e17, delta=1e15)
-        self.assertAlmostEqual(integrated_total_poc_ci95_UL, 1.95e17, delta=1e15)
-        self.assertAlmostEqual(integrated_total_poc_ci95_LL, 2.46e16, delta=1e15)
+        self.assertAlmostEqual(integrated_total_poc_mean, 2.301e17, delta=1e15)
+        self.assertAlmostEqual(integrated_total_poc_ci95_UL, 3.67e17, delta=1e15)
+        self.assertAlmostEqual(integrated_total_poc_ci95_LL, 3.752e16, delta=1e15)
 
 
 class Test2Phase(unittest.TestCase):
@@ -189,9 +189,9 @@ class Test2Phase(unittest.TestCase):
             os.path.join("tests", "ModelOutput", "2-phase", "posts", "integrated_totals", "ens_integrated_totals_ci95_LL_poc.csv")
         )["total"].iat[0]
     
-        self.assertAlmostEqual(integrated_total_poc_mean, 2.55e17, delta=1e15)
-        self.assertAlmostEqual(integrated_total_poc_ci95_UL, 3.92e+17, delta=1e15)
-        self.assertAlmostEqual(integrated_total_poc_ci95_LL, 1.44e+17, delta=1e15)
+        self.assertAlmostEqual(integrated_total_poc_mean, 3.27e17, delta=1e15)
+        self.assertAlmostEqual(integrated_total_poc_ci95_UL, 5.267e+17, delta=1e15)
+        self.assertAlmostEqual(integrated_total_poc_ci95_LL, 1.795e+17, delta=1e15)
 
 
 


### PR DESCRIPTION
Adds logger output to tune.py with which fit was best, log or nolog, when log=='both' is passed as an arguement.
```
            if log == 'both':
                logger.info(f"best fit: {reg_grid_search.cv_results_['best_transformation']}")
```