### PR TITLE
Fix three bugs in area_of_applicability

### DIFF
--- a/abil/analyze.py
+++ b/abil/analyze.py
@@ -145,12 +145,16 @@ def area_of_applicability(
         d_mins = numpy.empty((X_train.shape[0],))
         mean_acc_num = 0
         mean_acc_den = 0
-        for test_ix, train_ix in cv.split(X_train):
+        # sklearn cross-validator `split` yields (train_idx, test_idx); the
+        # previous unpacking was reversed, so d_mins was populated for
+        # in-fold points (overwritten k-1 times per index) instead of the
+        # held-out points (each filled exactly once).
+        for train_ix, test_ix in cv.split(X_train):
             hold_to_seen_d = train_distance[test_ix.reshape(-1,1), train_ix]
             d_mins[test_ix] = hold_to_seen_d.min(axis=1)
             mean_acc_num += hold_to_seen_d.sum()
             mean_acc_den += hold_to_seen_d.size
-        d_mean = mean_acc_num/mean_acc_den    
+        d_mean = mean_acc_num/mean_acc_den
     else:
         d_mins = train_distance.min(axis=1)
         numpy.fill_diagonal(train_distance, 0)
@@ -159,7 +163,8 @@ def area_of_applicability(
     di_train = d_mins / d_mean
 
     if threshold == "tukey":
-        lo_hinge, hi_hinge = numpy.percentile(di_train, (0.25, 0.75))
+        # numpy.percentile expects values in [0, 100], not [0, 1].
+        lo_hinge, hi_hinge = numpy.percentile(di_train, (25, 75))
         iqr = hi_hinge - lo_hinge
         cutpoint = iqr * 1.5 + hi_hinge
     elif threshold == "mad":
@@ -167,7 +172,9 @@ def area_of_applicability(
         mad = numpy.median(numpy.abs(di_train - median))
         cutpoint = median + 3 * mad
     elif (0 < threshold) & (threshold < 1):
-        cutpoint = numpy.percentile(di_train, threshold)
+        # threshold is documented as a quantile in (0, 1); scale to the
+        # 0-100 range numpy.percentile expects.
+        cutpoint = numpy.percentile(di_train, threshold * 100)
     cutpoint = numpy.maximum(cutpoint, di_train.max())
 
     if return_all:


### PR DESCRIPTION
sorry! Reworking through this code an i caught two bugs in using numpy.percentile (caused by the difference between it and pandas) and one train/test confusion that didn’t affect validity 

1. Tukey threshold percentile scale (0.25, 0.75) -> (25, 75) numpy.percentile expects values in [0, 100], not [0, 1]. The old calls were essentially returning the minimum of di_train for both hinges, so IQR collapsed to ~0 and the Tukey cutoff was always the 75th-percentile-ish value of di_train -- then the next line (cutpoint = numpy.maximum(cutpoint, di_train.max())) clamped it up to the max anyway, hiding the bug.

2. Float-threshold percentile scale: numpy.percentile(di_train, t) where t in (0, 1). Same scale issue. Documentation says the user passes a quantile in (0, 1); convert to percentile via threshold * 100.

3. CV-split unpack order: sklearn CrossValidator.split() yields (train_idx, test_idx). The previous loop unpacked them as (test_ix, train_ix), so: 
- d_mins[test_ix] = ... was actually d_mins[train_ix_real], overwritten (k-1) times per index (one per fold the point appeared in as training data) instead of filled exactly once for each held-out point. 
- hold_to_seen_d was train->test distance, not the intended holdout->in-fold distance. 

it’s important to note this is **symmetric in Euclidean so the distance values weren't wrong per se,** but the rows fed to d_mins[test_ix] = ...min(axis=1) corresponded to the wrong points. Restores the documented semantics: each held-out point's minimum distance to its training fold, recorded once per point.

Further we weren’t using the tukey cutoff, but it’s useful to correct just in case. 